### PR TITLE
Add option to set alternative pacman command

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -48,6 +48,20 @@ Comma-separated list of package groups.  May be specified multiple times.
 Packages are automatically in the C<meta> group.  Overrides groups loaded from
 an existing package.
 
+=item B<-p>, B<--pacman>=I<command>
+
+Command or path of alternative pacman binary. (Must be compatible with
+pacman sub-commands.)
+
+=item B<--not-as-root>
+
+Run the pacman command as the current user on package installation.
+
+=item B<--depends-first>
+
+Install dependencies in a separate call to pacman before installing
+the meta-package.
+
 =item B<--no-update>
 
 Do not search for an existing package to load information.


### PR DESCRIPTION
This PR introduces the ability to pick a different pacman command to run when searching for installed packages and installing the meta-package. This is mainly useful for using aur helpers.

The option to provide an alternative pacman command is -p or --pacman, followed by the command name or its path.

With the use of aur helpers in mind, it also adds the following options:

- --not-as-root: Run installation command as unpriviledged user

- --depends-first: Run a separate instance of pacman (or the provided alternative) to install the dependencies before installing the meta-package itself.

I think it's a bit cumbersome to actually use these with my usual aur helpers (paru and yay), since I need to provide all three of these options every time. But I figured having them separate might be better, since it wouldn't be situation-specific.
Also, I'm not that well versed in BASH, so the code may not be the best. Please do tell me where it can be improved.